### PR TITLE
Fix amount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,7 +79,7 @@ function authenticate(name, password) {
 // and return an array of js objects which will be saved to the cozy by saveBills (https://github.com/cozy/cozy-konnector-libs/blob/master/docs/api.md#savebills)
 function parseDocuments($) {
   // you can find documentation about the scrape function here :
-  const re = /.*(\d\d\/\d\d\/\d\d\d\d).*(\d\d\/\d\d\/\d\d\d\d).*(\d+,\d\d)\s+(\S+).*/
+  const re = /.*(\d\d\/\d\d\/\d\d\d\d).*(\d\d\/\d\d\/\d\d\d\d)[\s.]*(\d+,\d\d)\s+(\S+).*/
   const vendor = 'Mediapart'
   const date = new Date()
   const version = 1


### PR DESCRIPTION
Corrige le bug sur des montants détecté à 1€ au lieu de 11€.

Le . de l'expression régulière ne fetche pas les espaces non sécables. C'était la cause du bug.
